### PR TITLE
Mark whether insulin types can be given by a pump

### DIFF
--- a/LoopKit/InsulinKit/InsulinType.swift
+++ b/LoopKit/InsulinKit/InsulinType.swift
@@ -66,4 +66,13 @@ public enum InsulinType: Int, Codable, CaseIterable {
             return LocalizedString("Afrezza is an ultra rapid-acting mealtime insulin that is breathed in through your lungs using an oral inhaler and made by MannKind", comment: "Description for afrezza insulin type")
         }
     }
+    
+    public var pumpAdministerable: Bool {
+        switch self {
+        case .afrezza:
+            return false
+        default:
+            return true
+        }
+    }
 }


### PR DESCRIPTION
This PR adds UI logic to ensure Afrezza (and other insulin types that cannot be administered by an insulin pump) do not appear as options when setting up an insulin pump.